### PR TITLE
loose dag

### DIFF
--- a/R/as_data.R
+++ b/R/as_data.R
@@ -34,7 +34,7 @@ as_data <- function (x)
 # if it's already a *data* greta_array fine, else error
 #' @export
 as_data.greta_array <- function (x) {
-  if (x$node$type != 'data') {
+  if (!inherits(x$node, 'data_node')) {
     stop ('cannot coerce a non-data greta_array to data',
           call. = FALSE)
   }

--- a/R/dag_class.R
+++ b/R/dag_class.R
@@ -20,7 +20,7 @@ dag_class <- R6Class(
       self$target_nodes <- lapply(target_greta_arrays, member, 'node')
 
       # stash the node names, types, and tf names
-      self$node_types <- vapply(self$node_list, member, 'type', FUN.VALUE = '')
+      self$node_types <- vapply(self$node_list, node_type, FUN.VALUE = '')
       self$node_tf_names <- self$make_names()
 
       # set up the tf environment

--- a/R/distributions.R
+++ b/R/distributions.R
@@ -59,7 +59,7 @@ uniform_distribution <- R6Class (
 
     # weird hack to make TF see a gradient here
     tf_log_density_function = function (x, parameters) {
-      self$log_density + tf$reduce_sum(x * 0)
+      self$log_density + x * 0
     }
 
   )

--- a/R/extract_replace_combine.R
+++ b/R/extract_replace_combine.R
@@ -151,7 +151,7 @@ tf_replace <- function (x, value, index, dims) {
   rm('._dummy_in', envir = pf)
 
   # if this is a data node, also subset the values and pass on
-  if ('data' %in% x$node$type) {
+  if (inherits(x$node, 'data_node')) {
 
     values_in <- x$node$value()
     call_list <- as.list(call)[-1]

--- a/R/greta_array_class.R
+++ b/R/greta_array_class.R
@@ -121,7 +121,7 @@ print.greta_array <- function (x, ...) {
 summary.greta_array <- function (object, ...) {
   # array type
   type_text <- sprintf("'%s' greta array",
-                       object$node$type)
+                       node_type(object$node))
 
   len <- length(object)
   if (len == 1) {

--- a/R/greta_package.R
+++ b/R/greta_package.R
@@ -48,6 +48,8 @@ node_list_object <- R6Class(
     flush = function ()
       self$node_list <- list(),
 
+    registered_names = function() names(self$node_list),
+
     # return list of nodes. If `names` is provided, return only those
     nodes = function (names = NULL) {
       nodes <- self$node_list

--- a/R/greta_package.R
+++ b/R/greta_package.R
@@ -38,39 +38,14 @@
 #' }
 NULL
 
-# unexported object to hold the list of defined nodes
-node_list_object <- R6Class(
-  'node_list_object',
-  public = list(
-
-    node_list = list(),
-
-    flush = function ()
-      self$node_list <- list(),
-
-    registered_names = function() names(self$node_list),
-
-    # return list of nodes. If `names` is provided, return only those
-    nodes = function (names = NULL) {
-      nodes <- self$node_list
-      if (!is.null(names))
-        nodes <- nodes[names]
-      nodes
-    }
-
-  )
-)
-
 # crate the node list object whenever the package is loaded
 .onLoad <- function (libname, pkgname) {
 
   # silence TF's CPU instructions message
   Sys.setenv(TF_CPP_MIN_LOG_LEVEL=2)
 
+  # warn if TF version is bad
   check_tf_version('warn')
-
-  # set up the node list
-  options(nodes = node_list_object$new())
 
 }
 

--- a/R/node_class.R
+++ b/R/node_class.R
@@ -8,7 +8,6 @@ node <- R6Class(
     children = list(),
     parents = list(),
     .value = array(NA),
-    .fixed_value = FALSE,
     dim = NA,
     distribution = NULL,
 
@@ -202,9 +201,6 @@ node <- R6Class(
         self$.value
 
       } else {
-
-        if (self$.fixed_value)
-          stop ('this node has a fixed value; it cannot be reset')
 
         # get the dimension of the new value
         dim <- dim(new_value)

--- a/R/node_class.R
+++ b/R/node_class.R
@@ -5,8 +5,6 @@ node <- R6Class(
 
     type = 'undefined',
     unique_name = '',
-    name = 'nameless',
-    registered = FALSE,
     children = list(),
     parents = list(),
     .value = array(NA),
@@ -27,37 +25,39 @@ node <- R6Class(
         value <- unknowns(dim = dim)
 
       self$value(value)
-      self$register()
-      self$unique_name <- capture.output(self$.__enclos_env__)
+      self$get_unique_name()
 
     },
 
-    register = function () {
+    register = function (dag) {
+      if (! (self$unique_name %in% names(dag$node_list)))
+        dag$node_list[[self$unique_name]] <- self
+    },
 
-      # register this node in the global list, as soon as it is assigned a name
-      .nodes <- options()$nodes
-      name <- 'node'
-      current_nodes <- .nodes$nodes()
-      node_names <- names(current_nodes)
-      if (name %in% node_names) {
-        # find a unique name for it (adding numbers to the end)
-        good_name <- FALSE
-        counter <- 1
-        while (!good_name) {
-          counter <- counter + 1
-          proposed_name <- paste0(name, counter)
-          if (!proposed_name %in% node_names)
-            good_name <- TRUE
-        }
-        name <- proposed_name
+    # recursively register self and family
+    register_family = function (dag) {
+
+      if (! (self$unique_name %in% names(dag$node_list))) {
+
+        # add self to list
+        self$register(dag)
+
+        # find my immediate family (not including self)
+        family <- c(self$parents, self$children)
+
+        # get and assign their names
+        family_names <- vapply(family, member, 'unique_name', FUN.VALUE = '')
+        names(family) <- family_names
+
+        # find the unregistered ones
+        unregistered_idx <- which(! (family_names %in% names(dag$node_list)))
+        unregistered <- family[unregistered_idx]
+
+        # add them to the node list
+        for (relative in unregistered)
+          relative$register_family(dag)
+
       }
-
-      # assign name and add to register
-      self$node_name(name)
-      current_nodes[[name]] <- self
-      .nodes$node_list <- current_nodes
-      options(nodes = .nodes)
-      self$registered <- TRUE
 
     },
 
@@ -65,9 +65,8 @@ node <- R6Class(
 
       # if the node is already listed as a child, clone and re-register it to a
       # new name
-      if (node$name %in% self$child_names()) {
+      if (node$unique_name %in% self$child_names()) {
         node <- node$clone()
-        node$register()
       }
 
       # add to list of children
@@ -79,20 +78,18 @@ node <- R6Class(
     remove_child = function (node) {
 
       # remove node from list of children
-      rem_idx <- self$child_names() == node$name
+      rem_idx <- which(self$child_names() == node$unique_name)
       self$children <- self$children[-rem_idx]
       node$remove_parent(self)
 
     },
 
-
     add_parent = function (node) {
 
       # if the node is already listed as a parent, clone and re-register it to a
       # new name
-      if (node$name %in% self$parent_names()) {
+      if (node$unique_name %in% self$parent_names()) {
         node <- node$clone()
-        node$register()
       }
 
       # add to list of children
@@ -103,16 +100,9 @@ node <- R6Class(
     remove_parent = function (node) {
 
       # remove node from list of children
-      rem_idx <- self$parent_names() == node$name
+      rem_idx <- which(self$parent_names() == node$unique_name)
       self$parents <- self$parents[-rem_idx]
 
-    },
-
-    # get or set the name of this node
-    node_name = function (name = NULL) {
-      if (!is.null(name))
-        self$name <- name
-      self$name
     },
 
     # return the names of all child nodes, and if recursive = TRUE, all nodes
@@ -125,7 +115,7 @@ node <- R6Class(
       if (length(children) > 0) {
 
         names <- vapply(children,
-                        function(x) x$name,
+                        function(x) x$unique_name,
                         '')
 
         if (recursive) {
@@ -140,7 +130,7 @@ node <- R6Class(
       } else {
         # otherwise return own name (to make sure at least somethign is returned
         # on recursion)
-        names <- self$node_name()
+        names <- self$unique_name
       }
 
       names
@@ -154,7 +144,7 @@ node <- R6Class(
       if (length(parents) > 0) {
 
         names <- vapply(parents,
-                        function(x) x$name,
+                        function(x) x$unique_name,
                         '')
 
         if (recursive) {
@@ -169,31 +159,36 @@ node <- R6Class(
       } else {
         # otherwise return own name (to make sure at least somethign is returned
         # on recursion)
-        names <- self$node_name()
+        names <- self$unique_name
       }
 
       names
 
     },
 
+    defined = function (dag) {
+      tf_name <- dag$tf_name(self)
+      tf_name %in% ls(dag$tf_environment)
+    },
+
     # define this and all descendent objects on tensorflow graph in environment env
-    define_tf = function (env) {
+    define_tf = function (dag) {
 
       # if defined already, skip
-      if (!self$name %in% ls(env)) {
+      if (!self$defined(dag)) {
 
         # make sure children are defined
         children_defined <- vapply(self$children,
-                                   function(x) x$name %in% (ls(env)),
+                                   function(x) x$defined(dag),
                                    FUN.VALUE = FALSE)
 
         if (any(!children_defined)) {
           lapply(self$children[which(!children_defined)],
-                 function(x) x$define_tf(env))
+                 function(x) x$define_tf(dag))
         }
 
         # then define self
-        self$tf(env)
+        self$tf(dag)
 
       }
 
@@ -250,6 +245,15 @@ node <- R6Class(
       }
 
       text
+
+    },
+
+    get_unique_name = function () {
+
+      name <- capture.output(self$.__enclos_env__)
+      name <- gsub('<environment: ', 'node_', name)
+      name <- gsub('>', '', name)
+      self$unique_name <- name
 
     }
 

--- a/R/node_class.R
+++ b/R/node_class.R
@@ -2,8 +2,6 @@
 node <- R6Class(
   'node',
   public = list(
-
-    type = 'undefined',
     unique_name = '',
     children = list(),
     parents = list(),
@@ -231,7 +229,7 @@ node <- R6Class(
     # return a string describing this node, for use in print and summary etc.
     description = function () {
 
-      text <- self$type
+      text <- node_type(self)
 
       if (!is.null(self$distribution)) {
         text <- paste(text,

--- a/R/node_types.R
+++ b/R/node_types.R
@@ -5,8 +5,6 @@ data_node <- R6Class(
   inherit = node,
   public = list(
 
-    type = 'data',
-
     initialize = function (data) {
 
       # coerce data from common formats to an array here
@@ -35,7 +33,6 @@ operation_node <- R6Class(
   inherit = node,
   public = list(
 
-    type = 'operation',
     .operation = NA,
     .operation_args = NA,
     arguments = list(),
@@ -132,7 +129,6 @@ variable_node <- R6Class (
   inherit = node,
   public = list(
 
-    type = 'variable',
     constraint = NULL,
     lower = -Inf,
     upper = Inf,
@@ -270,7 +266,6 @@ distribution_node <- R6Class (
   'distribution_node',
   inherit = node,
   public = list(
-    type = 'distribution',
     distribution_name = 'no distribution',
     discrete = NA,
     target = NULL,
@@ -395,15 +390,12 @@ distribution_node <- R6Class (
 
     add_parameter = function (parameter, name) {
 
-      # coerce to a node, add as a child and register as a parameter
-
-      # just add as a scalar numeric (not a constant node) here.
-      # ensure that the value can be fetched
       parameter <- to_node(parameter)
       self$add_child(parameter)
       self$parameters[[name]] <- parameter
 
     }
 
-  ))
+  )
+)
 

--- a/R/node_types.R
+++ b/R/node_types.R
@@ -1,19 +1,8 @@
-deterministic_node <- R6Class(
-  'deterministic_node',
-  inherit = node,
-  public = list(
-
-    type = 'deterministic'
-
-  )
-)
-
-
 # different types of node
 
 data_node <- R6Class(
   'data_node',
-  inherit = deterministic_node,
+  inherit = node,
   public = list(
 
     type = 'data',
@@ -43,7 +32,7 @@ data_node <- R6Class(
 # a node for applying operations to values
 operation_node <- R6Class(
   'operation_node',
-  inherit = deterministic_node,
+  inherit = node,
   public = list(
 
     type = 'operation',

--- a/R/node_types.R
+++ b/R/node_types.R
@@ -32,10 +32,10 @@ data_node <- R6Class(
 
     },
 
-    tf = function (env) {
-      assign(self$name,
+    tf = function (dag) {
+      assign(dag$tf_name(self),
              tf$constant(self$value(), dtype = tf$float32),
-             envir = env)
+             envir = dag$tf_environment)
     }
   )
 )
@@ -107,7 +107,7 @@ operation_node <- R6Class(
       op
     },
 
-    tf = function (env) {
+    tf = function (dag) {
 
       # switch out the op for non-sugared variety
       op <- self$switch_op(self$.operation)
@@ -116,8 +116,8 @@ operation_node <- R6Class(
       fun <- eval(parse(text = op))
 
       # fetch the tensors for the environment
-      arg_names <- self$child_names(recursive = FALSE)
-      args <- lapply(arg_names, function (x) get(x, envir = env))
+      arg_tf_names <- lapply(self$children, dag$tf_name)
+      args <- lapply(arg_tf_names, get, envir = dag$tf_environment)
 
       # fetch additional (non-tensor) arguments, if any
       if (length(self$.operation_args) > 0)
@@ -127,7 +127,7 @@ operation_node <- R6Class(
       node <- do.call(fun, args)
 
       # assign it in the environment
-      assign(self$name, node, envir = env)
+      assign(dag$tf_name(self), node, envir = dag$tf_environment)
 
     }
   )
@@ -208,31 +208,32 @@ variable_node <- R6Class (
 
     },
 
-    tf = function (env) {
+    tf = function (dag) {
 
-      # omake a Variable tensor to hold the free state
+      # make a Variable tensor to hold the free state
       tf_obj <- tf$Variable(initial_value = self$value(),
                             dtype = tf$float32)
 
       # assign this as the free state
-      free_name <- sprintf('%s_free',
-                           self$name)
+      tf_name <- dag$tf_name(self)
+
+      free_name <- sprintf('%s_free', tf_name)
       assign(free_name,
              tf_obj,
-             envir = env)
+             envir = dag$tf_environment)
 
       # map from the free to constrained state in a new tensor
 
       # fetch the free node
-      tf_free <- get(free_name, envir = env)
+      tf_free <- get(free_name, envir = dag$tf_environment)
 
       # appy transformation
-      node <- self$tf_from_free(tf_free, env)
+      node <- self$tf_from_free(tf_free, dag$tf_environment)
 
       # assign back to environment with base name (density will use this)
-      assign(self$name,
+      assign(tf_name,
              node,
-             envir = env)
+             envir = dag$tf_environment)
 
     },
 
@@ -326,27 +327,27 @@ distribution_node <- R6Class (
 
     },
 
-    tf = function (env) {
+    tf = function (dag) {
 
       # define a tensor with this node's log density in env
 
       # run the TF version of the density function
-      tf_obj <- self$tf_log_density(env)
+      tf_obj <- self$tf_log_density(dag)
 
       # assign the result back to env
-      density_name <- sprintf('%s_density',
-                              self$name)
-      assign(density_name,
+      assign(dag$tf_name(self),
              tf_obj,
-             envir = env)
+             envir = dag$tf_environment)
 
     },
 
-    tf_log_density = function (env) {
+    tf_log_density = function (dag) {
 
       # fetch inputs
-      tf_target <- get(self$target$name, envir = env)
-      tf_parameters <- self$tf_fetch_parameters(env)
+
+      tf_target <- get(dag$tf_name(self$target),
+                       envir = dag$tf_environment)
+      tf_parameters <- self$tf_fetch_parameters(dag)
 
       # calculate log density
       ld <- self$tf_log_density_function(tf_target, tf_parameters)
@@ -358,15 +359,15 @@ distribution_node <- R6Class (
       ld
     },
 
-    tf_fetch_parameters = function (env) {
+    tf_fetch_parameters = function (dag) {
       # fetch the tensors corresponding to this node's parameters from the
       # environment, and return them in a named list
 
       # find names
-      names <- lapply(self$parameters, member, 'name')
+      tf_names <- lapply(self$parameters, dag$tf_name)
 
       # fetch tensors
-      lapply(names, function (x) get(x, envir = env))
+      lapply(tf_names, get, envir = dag$tf_environment)
 
     },
 

--- a/R/node_types.R
+++ b/R/node_types.R
@@ -1,5 +1,3 @@
-# different types of node
-
 data_node <- R6Class(
   'data_node',
   inherit = node,

--- a/R/samplers.R
+++ b/R/samplers.R
@@ -135,11 +135,13 @@ mcmc <- function (model,
   names <- names(target_greta_arrays)
 
   # check they're not data nodes, provide a useful error message if they are
-  type <- vapply(target_greta_arrays, member, 'node$type', FUN.VALUE = '')
-  bad <- type == 'data'
-  if (any(bad)) {
-    is_are <- ifelse(sum(bad) == 1, 'is a data greta array', 'are data greta arrays')
-    bad_greta_arrays <- paste(names[bad], collapse = ', ')
+  are_data <- vapply(target_greta_arrays,
+                     function (x) inherits(x$node, 'data_node'),
+                     FUN.VALUE = FALSE)
+
+  if (any(are_data)) {
+    is_are <- ifelse(sum(are_data) == 1, 'is a data greta array', 'are data greta arrays')
+    bad_greta_arrays <- paste(names[are_data], collapse = ', ')
     msg <- sprintf('%s %s, data greta arrays cannot be sampled',
                    bad_greta_arrays,
                    is_are)

--- a/R/samplers.R
+++ b/R/samplers.R
@@ -58,20 +58,18 @@ define_model <- function (...) {
   # get the dag containing the target nodes
   dag <- dag_class$new(target_greta_arrays)
 
-  # check they have a density among them
-  distribs <- dag$child_names(types = 'distribution')
+  # get and check the types
+  types <- dag$node_types
 
-  if (length(distribs) == 0) {
+  # check they have a density among them
+  if (!('distribution' %in% types)) {
     stop ('none of the greta arrays in the model are associated with a ',
           'probability density, so a model cannot be defined',
           call. = FALSE)
   }
 
-  # check they have an unknown node among them
-  unknown <- dag$child_names(types = 'variable',
-                             omit_fixed = TRUE)
-
-  if (length(unknown) == 0) {
+  # check they have a variable node among them
+  if (!('variable' %in% types)) {
     stop ('none of the greta arrays in the model are unknown, so a model ',
           'cannot be defined',
           call. = FALSE)

--- a/R/samplers.R
+++ b/R/samplers.R
@@ -32,6 +32,8 @@ define_model <- function (...) {
 
   check_tf_version('error')
 
+  tf$reset_default_graph()
+
   # nodes required
   target_greta_arrays <- list(...)
 

--- a/R/syntax.R
+++ b/R/syntax.R
@@ -72,7 +72,7 @@
   }
 
   # that aren't already fixed
-  if (distribution_node$.fixed_value) {
+  if (inherits(distribution_node$target, 'data_node')) {
     stop ('right hand side has already been assigned fixed values',
           call. = FALSE)
   }
@@ -92,10 +92,6 @@
   # assign the new node as the distribution's target
   # also adds distribution_node as this node's distribution
   distribution_node$replace_target(greta_array$node)
-
-  # optionally set that as a fixed value
-  if (inherits(greta_array$node, 'data_node'))
-    distribution_node$.fixed_value <- TRUE
 
   # if the greta_array was a variable, check its constraints as truncation
   if (inherits(greta_array$node, 'variable_node')) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -180,7 +180,7 @@ all_greta_arrays <- function (env = parent.frame(),
   if (!include_data) {
 
     is_data <- vapply(all_arrays,
-                      function (x) x$node$type == 'data',
+                      function(x) inherits(x$node, 'data_node'),
                       FUN.VALUE = FALSE)
     all_arrays <- all_arrays[!is_data]
 
@@ -251,3 +251,8 @@ flat_to_symmetric <- function (x, dim) {
 
 }
 
+node_type <- function (node) {
+  classes <- class(node)
+  type <- grep('*_node', classes, value = TRUE)
+  gsub('_node', '', type)
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -251,4 +251,3 @@ flat_to_symmetric <- function (x, dim) {
 
 }
 
-

--- a/tests/testthat/helpers.R
+++ b/tests/testthat/helpers.R
@@ -3,11 +3,6 @@
 # set the seed before running tests
 set.seed(2017-05-01)
 
-# flush the node list and tensor graph
-flush <- function () {
-  tf$reset_default_graph()
-}
-
 # evaluate a greta_array, node, or tensor
 grab <- function (x) {
 
@@ -44,6 +39,8 @@ compare_distribution <- function (greta_fun, r_fun, parameters, x) {
   # x is the vector of values at which to evaluate the log density
 
   # define greta distribution, with fixed values
+
+  tf$reset_default_graph()
 
   parameters_greta <- parameters
   # no dim for wishart
@@ -95,6 +92,8 @@ randu <- function (...) {
 # e.g. check_op(sum, randn(100, 3))
 check_op <- function (op, a, b, greta_op = NULL) {
 
+  tf$reset_default_graph()
+
   if (is.null(greta_op))
     greta_op <- op
 
@@ -110,22 +109,6 @@ check_op <- function (op, a, b, greta_op = NULL) {
   difference <- as.vector(abs(r_out - greta_out))
   expect_true(all(difference < 1e-4))
 }
-
-# take an expression, and execute it, converting the objects named in 'swap' to
-# greta arrays
-
-# call_to_text <- function (call)
-#   paste(deparse(call), collapse = ' ')
-
-# # can check with_greta works with this code:
-# foo <- function (x) {
-#   if(inherits(x, 'greta_array'))
-#     stop ('noooo')
-#   x
-# }
-# x <- randn(3)
-# foo(3)
-# with_greta(foo(3), swap = 'x')
 
 # execute a call via greta, swapping the objects named in 'swap' to greta
 # arrays, then converting the result back to R. 'swap_scope' tells eval() how
@@ -160,6 +143,9 @@ with_greta <- function (call, swap = c('x'), swap_scope = 1) {
 # arrays with results ported back to R
 # e.g. check_expr(a[1:3], swap = 'a')
 check_expr <- function (expr, swap = c('x')) {
+
+  tf$reset_default_graph()
+
   call <- substitute(expr)
 
   r_out <- eval(expr)
@@ -227,6 +213,8 @@ compare_truncated_distribution <- function (greta_fun, which, parameters, trunca
   # is a greta array created from a distribution and a constrained free() greta
   # array. 'r_fun' is an r function returning the log density for the same
   # truncated distribution, taking x as its only argument.
+
+  tf$reset_default_graph()
 
   require(truncdist)
 

--- a/tests/testthat/test_as_data.R
+++ b/tests/testthat/test_as_data.R
@@ -4,8 +4,6 @@ test_that('as_data coerces correctly', {
 
   source('helpers.R')
 
-  flush()
-
   # logical, integer and numeric
   # vector, matrix, array, dataframe
 
@@ -111,8 +109,6 @@ test_that('as_data coerces correctly', {
 test_that('as_data errors informatively', {
 
   source('helpers.R')
-
-  flush()
 
   # wrong class of object
   expect_error(as_data(NULL),

--- a/tests/testthat/test_distributions.R
+++ b/tests/testthat/test_distributions.R
@@ -4,8 +4,6 @@ test_that('normal distribution has correct density', {
 
   source('helpers.R')
 
-  flush()
-
   difference <- compare_distribution(greta::normal,
                                      stats::dnorm,
                                      parameters = list(mean = -2, sd = 3),
@@ -18,8 +16,6 @@ test_that('normal distribution has correct density', {
 test_that('uniform distribution has correct density', {
 
   source('helpers.R')
-
-  flush()
 
   difference <- compare_distribution(greta::uniform,
                                      stats::dunif,
@@ -34,8 +30,6 @@ test_that('lognormal distribution has correct density', {
 
   source('helpers.R')
 
-  flush()
-
   difference <- compare_distribution(greta::lognormal,
                                      stats::dlnorm,
                                      parameters = list(meanlog = 1, sdlog = 3),
@@ -48,8 +42,6 @@ test_that('lognormal distribution has correct density', {
 test_that('bernoulli distribution has correct density', {
 
   source('helpers.R')
-
-  flush()
 
   # r version of the bernoulli density
   dbern <- function (x, prob, log = FALSE)
@@ -68,8 +60,6 @@ test_that('binomial distribution has correct density', {
 
   source('helpers.R')
 
-  flush()
-
   difference <- compare_distribution(greta::binomial,
                                      stats::dbinom,
                                      parameters = list(size = 10, prob = 0.8),
@@ -82,8 +72,6 @@ test_that('binomial distribution has correct density', {
 test_that('negative binomial distribution has correct density', {
 
   source('helpers.R')
-
-  flush()
 
   difference <- compare_distribution(greta::negative_binomial,
                                      stats::dnbinom,
@@ -98,8 +86,6 @@ test_that('poisson distribution has correct density', {
 
   source('helpers.R')
 
-  flush()
-
   difference <- compare_distribution(greta::poisson,
                                      stats::dpois,
                                      parameters = list(lambda = 17.2),
@@ -112,8 +98,6 @@ test_that('poisson distribution has correct density', {
 test_that('gamma distribution has correct density', {
 
   source('helpers.R')
-
-  flush()
 
   difference <- compare_distribution(greta::gamma,
                                      stats::dgamma,
@@ -128,8 +112,6 @@ test_that('exponential distribution has correct density', {
 
   source('helpers.R')
 
-  flush()
-
   difference <- compare_distribution(greta::exponential,
                                      stats::dexp,
                                      parameters = list(rate = 1.9),
@@ -142,8 +124,6 @@ test_that('exponential distribution has correct density', {
 test_that('student distribution has correct density', {
 
   source('helpers.R')
-
-  flush()
 
   # use location-scale version of student T; related to R's via this function:
   dt_ls <- function (x, df, location, scale, log = FALSE) {
@@ -166,8 +146,6 @@ test_that('beta distribution has correct density', {
 
   source('helpers.R')
 
-  flush()
-
   difference <- compare_distribution(greta::beta,
                                      stats::dbeta,
                                      parameters = list(shape1 = 2.3, shape2 = 3.4),
@@ -180,8 +158,6 @@ test_that('beta distribution has correct density', {
 test_that('multivariate normal distribution has correct density', {
 
   source('helpers.R')
-
-  flush()
 
   # parameters to test
   m <- 5
@@ -204,8 +180,6 @@ test_that('multivariate normal distribution has correct density', {
 test_that('Wishart distribution has correct density', {
 
   source('helpers.R')
-
-  flush()
 
   # parameters to test
   m <- 5
@@ -235,8 +209,6 @@ test_that('scalar-valued distributions can be defined in models', {
 
   source('helpers.R')
 
-  flush()
-
   x <- randn(5)
   y <- round(randu(5))
   p <- iprobit(normal(0, 1))
@@ -258,20 +230,14 @@ test_that('scalar-valued distributions can be defined in models', {
   distribution(y) = poisson(p)
   define_model(p)
 
-  flush()
-
   # continuous distributions
   define_model(normal(-2, 3))
   define_model(student(5.6, -2, 2.3))
   define_model(lognormal(1.2, 0.2))
 
-  flush()
-
   define_model(gamma(0.9, 1.3))
   define_model(exponential(6.3))
   define_model(beta(6.3, 5.9))
-
-  flush()
 
   define_model(uniform(-13, 2.4))
   sig <- rWishart(4, 3, diag(3))[, , 1]
@@ -283,8 +249,6 @@ test_that('scalar-valued distributions can be defined in models', {
 test_that('array-valued distributions can be defined in models', {
 
   source('helpers.R')
-
-  flush()
 
   dim <- c(5, 2)
   x <- randn(5, 2)
@@ -308,21 +272,15 @@ test_that('array-valued distributions can be defined in models', {
   distribution(y) = poisson(p)
   define_model(p)
 
-  flush()
-
   # continuous distributions
   define_model(normal(-2, 3, dim = dim))
   define_model(student(5.6, -2, 2.3, dim = dim))
   define_model(lognormal(1.2, 0.2, dim = dim))
 
-  flush()
-
   define_model(gamma(0.9, 1.3, dim = dim))
   define_model(exponential(6.3, dim = dim))
   define_model(beta(6.3, 5.9, dim = dim))
   define_model(uniform(-13, 2.4, dim = dim))
-
-  flush()
 
   sig <- rWishart(4, 3, diag(3))[, , 1]
   define_model(multivariate_normal(rnorm(3), sig, dim = dim[1]))
@@ -332,8 +290,6 @@ test_that('array-valued distributions can be defined in models', {
 test_that('distributions can be sampled from', {
 
   source('helpers.R')
-
-  flush()
 
   x <- randn(100)
   y <- round(randu(100))
@@ -352,7 +308,6 @@ test_that('distributions can be sampled from', {
   distribution(x) = normal(c, 1)
   sample_distribution(c)
 
-
   d <- free(lower = 1.2, upper = 1.3)
   distribution(x) = normal(d, 1)
   sample_distribution(d)
@@ -370,26 +325,18 @@ test_that('distributions can be sampled from', {
   distribution(y) = poisson(p)
   sample_distribution(p)
 
-  flush()
-
   # unconstrained
   sample_distribution(normal(-2, 3))
   sample_distribution(student(5.6, -2, 2.3))
-
-  flush()
 
   # positive
   sample_distribution(lognormal(1.2, 0.2), lower = 0)
   sample_distribution(gamma(0.9, 1.3), lower = 0)
   sample_distribution(exponential(6.3), lower = 0)
 
-  flush()
-
   # constrained
   sample_distribution(beta(6.3, 5.9), lower = 0, upper = 1)
   sample_distribution(uniform(-13, 2.4), lower = -13, upper = 2.4)
-
-  flush()
 
   # multivariate
   sig <- rWishart(4, 3, diag(3))[, , 1]
@@ -402,8 +349,6 @@ test_that('distributions can be sampled from', {
 test_that('free distribution errors informatively', {
 
   source('helpers.R')
-
-  flush()
 
   # bad types
   expect_error(free(upper = NA),
@@ -429,8 +374,6 @@ test_that('uniform distribution errors informatively', {
 
   source('helpers.R')
 
-  flush()
-
   # bad types
   expect_error(uniform(min = 0, max = NA),
                'min and max must be numeric vectors of length 1')
@@ -453,8 +396,6 @@ test_that('wishart distribution errors informatively', {
 
   source('helpers.R')
 
-  flush()
-
   a <- randn(3, 3)
   b <- randn(3, 3, 3)
   c <- randn(3, 2)
@@ -472,8 +413,6 @@ test_that('wishart distribution errors informatively', {
 test_that('multivariate_normal distribution errors informatively', {
 
   source('helpers.R')
-
-  flush()
 
   m_a <- randn(3)
   m_b <- randn(3, 1)

--- a/tests/testthat/test_dynamics_module.R
+++ b/tests/testthat/test_dynamics_module.R
@@ -4,8 +4,6 @@ test_that('lambda iteration works', {
 
   source('helpers.R')
 
-  flush()
-
   n <- 10
   mat <- randu(n, n)
   init <- rep(1, n)
@@ -30,8 +28,6 @@ test_that('lambda iteration works', {
 test_that('state iteration works', {
 
   source('helpers.R')
-
-  flush()
 
   n <- 10
   mat <- randu(n, n)
@@ -59,8 +55,6 @@ test_that('state iteration works', {
 test_that('vectorised lambda iteration works', {
 
   source('helpers.R')
-
-  flush()
 
   n <- 10
   n_mat <- 20
@@ -94,8 +88,6 @@ test_that('vectorised lambda iteration works', {
 test_that('dynamics module errors informatively', {
 
   source('helpers.R')
-
-  flush()
 
   niter <- 3
   n <- 10
@@ -165,6 +157,5 @@ test_that('dynamics module errors informatively', {
                                                  n = n,
                                                  m = m),
                'number of elements in state must match the dimension of matrix')
-
 
 })

--- a/tests/testthat/test_extract_replace_combine.R
+++ b/tests/testthat/test_extract_replace_combine.R
@@ -4,8 +4,6 @@ test_that('extract works like R', {
 
   source('helpers.R')
 
-  flush()
-
   a <- randn(10)
   b <- randn(10, 1)
   c <- randn(10, 5)
@@ -17,8 +15,6 @@ test_that('extract works like R', {
   check_expr(c[1:6], 'c')
   check_expr(d[1:6], 'd')
 
-  flush()
-
   # can extract first column, regardless of dimension
   check_expr(b[1:6, ], 'b')
   check_expr(b[1:6, 1], 'b')
@@ -26,8 +22,6 @@ test_that('extract works like R', {
   check_expr(c[1:6, 1], 'c')
   check_expr(d[1:2, , ], 'd')
   check_expr(d[1:2, 1, , drop = FALSE], 'd')
-
-  flush()
 
   # can extract with negative dimensions
   check_expr(a[3:1], 'a')
@@ -39,29 +33,21 @@ test_that('extract works like R', {
   # can extract with a mix of numerics and logicals
   check_expr(d[2:1, , c(TRUE, FALSE), drop = FALSE], 'd')
 
-  flush()
-
   # can extract with missing entries in various places
   check_expr(d[, , 2:1], 'd')
   check_expr(d[, 2:1, ], 'd')
   check_expr(d[2:1, , ], 'd')
-
-  flush()
 
   # can extract single elements without dropping dimensions
   check_expr(d[, , 1, drop = FALSE], 'd')
   check_expr(d[, 1, , drop = FALSE], 'd')
   check_expr(d[1, , , drop = FALSE], 'd')
 
-  flush()
-
   # can do empty extracts
   check_expr(a[], 'a')
   check_expr(b[], 'b')
   check_expr(c[], 'c')
   check_expr(d[], 'd')
-
-  flush()
 
   # can do negative extracts
   check_expr(a[-1], 'a')
@@ -74,8 +60,6 @@ test_that('extract works like R', {
 test_that('replace works like R', {
 
   source('helpers.R')
-
-  flush()
 
   # check using expressions, and comparing the whole object to which replacement
   # was applied
@@ -90,8 +74,6 @@ test_that('replace works like R', {
   x <- randn(2, 2, 2)
   check_expr({x[1:6] <- seq_len(6); x})
 
-  flush()
-
   # can replace first column, regardless of dimension
   x <- randn(10, 1)
   check_expr({x[1:6, 1] <- seq_len(6 * 1); x})
@@ -100,8 +82,6 @@ test_that('replace works like R', {
   x <- randn(2, 2, 2)
   check_expr({x[1:2, 1, ] <- seq_len(2 * 1 * 2); x})
 
-  flush()
-
   # can replace a chunk, regardless of dimension
   x <- randn(10, 1)
   check_expr({x[1:6, ] <- seq_len(6); x})
@@ -109,8 +89,6 @@ test_that('replace works like R', {
   check_expr({x[1:6, ] <- seq_len(6 * 5); x})
   x <- randn(10, 2, 2)
   check_expr({x[1:2, , ] <- seq_len(2 * 2 * 2); x})
-
-  flush()
 
   # can replace with negative dimensions
   x <- randn(10)
@@ -121,8 +99,6 @@ test_that('replace works like R', {
   # can replace with logicals (the logical vector is repeated 3 1/3 times)
   x <- randn(10)
   check_expr({x[c(TRUE, FALSE, TRUE)] <- seq_len(7); x})
-
-  flush()
 
   # can extract with a mix of numerics and logicals
   x <- randn(10, 2, 2)
@@ -136,8 +112,6 @@ test_that('replace works like R', {
   x <- randn(10, 2, 2)
   check_expr({x[1:2, , ] <- seq_len(2 * 2 * 2); x})
 
-  flush()
-
   # can assign single elements without dropping dimensions
   x <- randn(10, 2, 2)
   check_expr({x[1, , ] <- seq_len(1 * 2 * 2); x})
@@ -145,8 +119,6 @@ test_that('replace works like R', {
   check_expr({x[, 1, ] <- seq_len(10 * 1 * 2); x})
   x <- randn(10, 2, 2)
   check_expr({x[, , 1] <- seq_len(10 * 2 * 1); x})
-
-  flush()
 
   # can do full replacements
   x <- randn(10)
@@ -158,8 +130,6 @@ test_that('replace works like R', {
   x <- randn(2, 2, 2)
   check_expr({x[] <- seq_len(2 * 2 * 2); x})
 
-  flush()
-
   # can do negative replacements
   x <- randn(10)
   check_expr({x[-1] <- seq_len(9); x})
@@ -169,8 +139,6 @@ test_that('replace works like R', {
   check_expr({x[-(1:4), ] <- seq_len(6 * 5); x})
   x <- randn(2, 2, 2)
   check_expr({x[-1, -1, ] <- seq_len(1 * 1 * 2); x})
-
-  flush()
 
   # can replace multiple entries with one;
   x <- randn(10)
@@ -182,8 +150,6 @@ test_that('replace works like R', {
   x <- randn(2, 2, 2)
   check_expr({x[1:2, , ] <- 1; x})
 
-  flush()
-
   # can replace multiple entries with a vector (with factorizing length)
   x <- randn(10)
   check_expr({x[1:4] <- seq_len(2); x})
@@ -193,8 +159,6 @@ test_that('replace works like R', {
   check_expr({x[1:9, ] <- seq_len(3); x})
   x <- randn(2, 2, 2)
   check_expr({x[1:2, , 1] <- seq_len(2); x})
-
-  flush()
 
   # replace with a greta array (e.g. with subset of self)
   # check_expr seems to balls this one up, so do it longhand
@@ -212,8 +176,6 @@ test_that('rep works like R', {
 
   source('helpers.R')
 
-  flush()
-
   a <- randn(10)
   b <- randn(10, 1)
   c <- randn(10, 5)
@@ -227,8 +189,6 @@ test_that('rep works like R', {
   check_op(rep_times, c)
   check_op(rep_times, d)
 
-  flush()
-
   rep_length <- function(x)
     rep(x, length.out = 3)
 
@@ -237,8 +197,6 @@ test_that('rep works like R', {
   check_op(rep_length, c)
   check_op(rep_length, d)
 
-  flush()
-
   rep_times_each <- function(x)
     rep(x, times = 3, each = 3)
 
@@ -246,8 +204,6 @@ test_that('rep works like R', {
   check_op(rep_times_each, b)
   check_op(rep_times_each, c)
   check_op(rep_times_each, d)
-
-  flush()
 
   rep_length_each <- function(x)
     rep(x, length = 30, each = 3)
@@ -263,8 +219,6 @@ test_that('rbind, cbind and c work like R', {
 
   source('helpers.R')
 
-  flush()
-
   a <- randn(5, 1)
   b <- randn(1, 5)
   d <- randn(5, 5)
@@ -277,14 +231,10 @@ test_that('rbind, cbind and c work like R', {
   check_op(cbind, a, d)
   check_op(cbind, d, d)
 
-  flush()
-
   # flatten and concatenate arrays
   check_op(c, a, d)
   check_op(c, b, a)
   check_op(c, d, b)
-
-  flush()
 
   # unary c flattens arrays
   check_op(c, a)
@@ -297,8 +247,6 @@ test_that('assign errors on variable greta arrays', {
 
   source('helpers.R')
 
-  flush()
-
   z <- normal(0, 1, dim = 5)
   expect_error(z[1] <- 3,
                'cannot replace values in a variable greta array')
@@ -308,8 +256,6 @@ test_that('assign errors on variable greta arrays', {
 test_that('rbind and cbind give informative error messages', {
 
   source('helpers.R')
-
-  flush()
 
   a <- as_data(randn(5, 1))
   b <- as_data(randn(1, 5))
@@ -326,8 +272,6 @@ test_that('replacement gives informative error messages', {
 
   source('helpers.R')
 
-  flush()
-
   x <- as_data(randn(2, 2, 2))
   expect_error(x[1:2, , 1] <- seq_len(3),
                'number of items to replace is not a multiple of replacement length')
@@ -337,8 +281,6 @@ test_that('replacement gives informative error messages', {
 test_that('stochastic and operation greta arrays can be extracted', {
 
   source('helpers.R')
-
-  flush()
 
   a = normal(0, 1, dim = c(3, 4))
   a_sub <- a[1:2, 2:3]

--- a/tests/testthat/test_functions.R
+++ b/tests/testthat/test_functions.R
@@ -4,8 +4,6 @@ test_that('simple functions work as expected', {
 
   source('helpers.R')
 
-  flush()
-
   x <- randn(25, 4)
 
   # logarithms and exponentials
@@ -14,22 +12,16 @@ test_that('simple functions work as expected', {
   check_op(log1p, exp(x))
   check_op(expm1, x)
 
-  flush()
-
   # miscellaneous mathematics
   check_op(abs, x)
   check_op(mean, x)
   check_op(sqrt, exp(x))
   check_op(sign, x)
 
-  flush()
-
   # rounding of numbers
   check_op(ceiling, x)
   check_op(floor, x)
   check_op(round, x)
-
-  flush()
 
   # trigonometry
   check_op(cos, x)
@@ -38,8 +30,6 @@ test_that('simple functions work as expected', {
   check_op(acos, 2 * plogis(x) - 1)
   check_op(asin, 2 * plogis(x) - 1)
   check_op(atan, x)
-
-  flush()
 
   # special mathematical functions
   check_op(lgamma, x)
@@ -50,8 +40,6 @@ test_that('simple functions work as expected', {
 test_that('matrix functions work as expected', {
 
   source('helpers.R')
-
-  flush()
 
   a <- rWishart(1, 6, diag(5))[, , 1]
   b <- randn(5, 25)
@@ -69,8 +57,6 @@ test_that('reducing functions work as expected', {
 
   source('helpers.R')
 
-  flush()
-
   a <- randn(1, 3)
   b <- randn(5, 25)
 
@@ -85,15 +71,11 @@ test_that('sweep works as expected', {
 
   source('helpers.R')
 
-  flush()
-
   stats_list <- list(randn(5), randn(25))
   x <- randn(5, 25)
 
   for (dim in c(1, 2)) {
     for (fun in c('-', '+', '/', '*')) {
-
-      flush()
 
       stats <- stats_list[[dim]]
 
@@ -115,8 +97,6 @@ test_that('sweep works as expected', {
 test_that('solve and sweep error as expected', {
 
   source('helpers.R')
-
-  flush()
 
   a <- as_data(randn(5, 25))
   b <- as_data(randn(5, 25, 2))

--- a/tests/testthat/test_greta_array_class.R
+++ b/tests/testthat/test_greta_array_class.R
@@ -4,8 +4,6 @@ test_that('print and summary work', {
 
   source('helpers.R')
 
-  flush()
-
   ga_data <- as_data(matrix(1:9, nrow = 3))
   ga_stochastic <- normal(0, 1)
   ga_operation <- ga_data * ga_stochastic
@@ -50,8 +48,6 @@ test_that('length and dim work', {
 
   source('helpers.R')
 
-  flush()
-
   ga_data <- as_data(matrix(1:9, nrow = 3))
   ga_stochastic <- normal(0, 1, dim = c(3, 3))
   ga_operation <- ga_data * ga_stochastic
@@ -71,8 +67,6 @@ test_that('length and dim work', {
 test_that('head and tail work', {
 
   source('helpers.R')
-
-  flush()
 
   a <- randn(10, 1)
   b <- randn(10, 4)

--- a/tests/testthat/test_misc.R
+++ b/tests/testthat/test_misc.R
@@ -89,8 +89,6 @@ test_that('define_model and mcmc error informatively', {
 
   source('helpers.R')
 
-  flush()
-
   x <- as_data(randn(10))
 
   # no model with non-probability density greta arrays
@@ -124,8 +122,6 @@ test_that('check_dims errors informatively', {
 
   source('helpers.R')
 
-  flush()
-
   a <- ones(3, 3)
   b <- ones(1)
   c <- ones(2, 2)
@@ -158,8 +154,6 @@ test_that('rejected mcmc proposals', {
 
   source('helpers.R')
 
-  flush()
-
   # numerical rejection
   x <- rnorm(10000, 1e6, 1)
   z = normal(-1e6, 1e-6)
@@ -167,8 +161,6 @@ test_that('rejected mcmc proposals', {
   m <- define_model(z)
   expect_message(mcmc(m, n_samples = 1, warmup = 0),
                  'proposal rejected due to numerical instability')
-
-  flush()
 
   # bad proposal
   x <- rnorm(100, 0, 0.01)

--- a/tests/testthat/test_operators.R
+++ b/tests/testthat/test_operators.R
@@ -4,8 +4,6 @@ test_that('arithmetic operators work as expected', {
 
   source('helpers.R')
 
-  flush()
-
   a <- randn(25, 4)
   b <- randn(25, 4)
 
@@ -25,8 +23,6 @@ test_that('logical operators work as expected', {
 
   source('helpers.R')
 
-  flush()
-
   a <- randn(25, 4) > 0
   b <- randn(25, 4) > 0
   a[] <- as.integer(a[])
@@ -41,8 +37,6 @@ test_that('logical operators work as expected', {
 test_that('relational operators work as expected', {
 
   source('helpers.R')
-
-  flush()
 
   a <- randn(25, 4)
   b <- randn(25, 4)
@@ -61,8 +55,6 @@ test_that('random strings of operators work as expected', {
   source('helpers.R')
 
   for (i in 1:10) {
-
-    flush()
 
     a <- randn(25, 4)
     b <- randn(25, 4)

--- a/tests/testthat/test_syntax.R
+++ b/tests/testthat/test_syntax.R
@@ -4,8 +4,6 @@ test_that('`distribution<-` works in models', {
 
   source('helpers.R')
 
-  flush()
-
   # with a distribution parameter
   y <- as_data(randn(5))
   expect_equal(node_type(y$node), 'data')
@@ -23,8 +21,6 @@ test_that('`distribution<-` works in models', {
   sample_distribution(mu)
 
   # with a free parameter
-
-  flush()
 
   y <- as_data(randn(5))
   expect_equal(node_type(y$node), 'data')
@@ -48,8 +44,6 @@ test_that('`distribution<-` works in models', {
 test_that('distribution() works', {
 
   source('helpers.R')
-
-  flush()
 
   a = normal(0, 1)
   b = free()
@@ -82,8 +76,6 @@ test_that('distribution() works', {
 test_that('`distribution<-` errors informatively', {
 
   source('helpers.R')
-
-  flush()
 
   y <- randn(3, 3, 2)
   x <- randn(1)
@@ -131,8 +123,6 @@ test_that('`distribution<-` errors informatively', {
 test_that('distribution() errors informatively', {
 
   source('helpers.R')
-
-  flush()
 
   y <- randn(3)
 

--- a/tests/testthat/test_syntax.R
+++ b/tests/testthat/test_syntax.R
@@ -8,9 +8,9 @@ test_that('`distribution<-` works in models', {
 
   # with a distribution parameter
   y <- as_data(randn(5))
-  expect_equal(y$node$type, 'data')
+  expect_equal(node_type(y$node), 'data')
   y_op <- y * 1
-  expect_equal(y_op$node$type, 'operation')
+  expect_equal(node_type(y_op$node), 'operation')
 
   # data
   mu <- normal(0, 1)
@@ -27,9 +27,9 @@ test_that('`distribution<-` works in models', {
   flush()
 
   y <- as_data(randn(5))
-  expect_equal(y$node$type, 'data')
+  expect_equal(node_type(y$node), 'data')
   y_op <- y * 1
-  expect_equal(y_op$node$type, 'operation')
+  expect_equal(node_type(y_op$node), 'operation')
 
   # data
   mu <- free()

--- a/tests/testthat/test_transformations.R
+++ b/tests/testthat/test_transformations.R
@@ -4,8 +4,6 @@ test_that('transformations work as expected', {
 
   source('helpers.R')
 
-  flush()
-
   a <- randn(25, 4)
 
   r_icloglog <- function (x)

--- a/tests/testthat/test_truncated.R
+++ b/tests/testthat/test_truncated.R
@@ -4,8 +4,6 @@ test_that('truncated distributions define correct densities', {
 
   source('helpers.R')
 
-  flush()
-
   # non-truncated normal (via truncation trick)
   difference <- compare_truncated_distribution(normal,
                                                'norm',


### PR DESCRIPTION
A refactor based around the dag_class

*switch to defining DAGs by traversing the graph starting at target nodes, removing the need for a global node list

* remove redundant methods in dag and node classes

* flush the TF graph before defining models, and in test utility functions
